### PR TITLE
重构并修正 `加载更多` 功能；在文章详情中添加订阅源链接；添加快捷键操作等

### DIFF
--- a/src/All.js
+++ b/src/All.js
@@ -1,45 +1,43 @@
-import { Message } from "@arco-design/web-react";
+import {Message} from "@arco-design/web-react";
 import Content from "./components/Content";
-import { getCurrentUser } from "./apis";
-import { thunder } from "./apis/axios";
+import {getCurrentUser} from "./apis";
+import {thunder} from "./apis/axios";
 
 export default function All() {
-  async function getEntries(offset = 0) {
-    const base_url = `/v1/entries?order=published_at&direction=desc`;
-    const url = offset ? `${base_url}&offset=${offset}` : base_url;
+    const getEntries = async (offset = 0) => {
+        const base_url = `/v1/entries?order=published_at&direction=desc`;
+        const url = offset ? `${base_url}&offset=${offset}` : base_url;
 
-    try {
-      const response = await thunder.request({ method: "get", url });
-      console.log(response);
-      return response;
-    } catch (error) {
-      console.error(error);
-      Message.error(error.message);
-    }
-  }
+        try {
+            const response = await thunder.request({method: "get", url});
+            console.log(response);
+            return response;
+        } catch (error) {
+            console.error(error);
+            Message.error(error.message);
+        }
+    };
 
-  async function markAllAsRead() {
-    const currentUser = await getCurrentUser();
-    try {
-      const response = await thunder.request({
-        method: "put",
-        url: `/v1/users/${currentUser.data.id}/mark-all-as-read`,
-      });
-      console.log(response);
-      return response;
-    } catch (error) {
-      console.error(error);
-      Message.error(error.message);
-    }
-  }
+    const markAllAsRead = async () => {
+        const currentUser = await getCurrentUser();
+        try {
+            const response = await thunder.request({
+                method: "put",
+                url: `/v1/users/${currentUser.data.id}/mark-all-as-read`,
+            });
+            console.log(response);
+            return response;
+        } catch (error) {
+            console.error(error);
+            Message.error(error.message);
+        }
+    };
 
-  return (
-    <>
-      <Content
-        info={{ from: "all", id: "" }}
-        getEntries={getEntries}
-        markAllAsRead={markAllAsRead}
-      />
-    </>
-  );
+    return (
+        <Content
+            info={{from: "all", id: ""}}
+            getEntries={getEntries}
+            markAllAsRead={markAllAsRead}
+        />
+    );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,508 +1,514 @@
 import _ from "lodash";
-import { create } from "zustand";
+import {create} from "zustand";
 import "./App.css";
-import { useEffect, useState } from "react";
+import {useEffect, useState} from "react";
 import {
-  Avatar,
-  Button,
-  Dropdown,
-  Form,
-  Input,
-  Layout,
-  Menu,
-  Message,
-  Modal,
-  Select,
-  Skeleton,
-  Space,
-  Switch,
-  Tooltip,
-  Typography,
+    Avatar,
+    Button,
+    Dropdown,
+    Form,
+    Input,
+    Layout,
+    Menu,
+    Message,
+    Modal,
+    Select,
+    Skeleton,
+    Space,
+    Switch,
+    Tooltip,
+    Typography,
 } from "@arco-design/web-react";
 import {
-  IconApps,
-  IconBook,
-  IconFile,
-  IconList,
-  IconMoonFill,
-  IconPlus,
-  IconPoweroff,
-  IconSettings,
-  IconSunFill,
-  IconUser,
+    IconApps,
+    IconBook,
+    IconFile,
+    IconList,
+    IconMoonFill,
+    IconPlus,
+    IconPoweroff,
+    IconSettings,
+    IconSunFill,
+    IconUser,
 } from "@arco-design/web-react/icon";
-import { Outlet, useNavigate, useLocation } from "react-router-dom";
-import { addFeed, getFeeds, getGroups, getUnreadInfo } from "./apis";
+import {Outlet, useNavigate, useLocation} from "react-router-dom";
+import {addFeed, getFeeds, getGroups, getUnreadInfo} from "./apis";
 import Settings from "./components/Settings";
 
 const MenuItem = Menu.Item;
-const SubMenu = Menu.SubMenu;
-const Sider = Layout.Sider;
+const {SubMenu} = Menu;
+const {Sider} = Layout;
 
 const useStore = create((set) => ({
-  feeds: [],
-  groups: [],
-  loading: true,
+    feeds: [],
+    groups: [],
+    loading: true,
+    totalUnread: 0,
+    initDataCompleted: false,
 
-  initData: async () => {
-    set({ loading: true });
-    const feedResponse = await getFeeds();
-    const groupResponse = await getGroups();
-    const unreadResponse = await getUnreadInfo();
+    initData: async () => {
+        set({loading: true});
+        const feedResponse = await getFeeds();
+        const groupResponse = await getGroups();
+        const unreadResponse = await getUnreadInfo();
 
-    if (feedResponse && unreadResponse && groupResponse) {
-      const unreadInfo = unreadResponse.data.unreads;
-      const feedsWithUnread = feedResponse.data.map((feed) => ({
-        ...feed,
-        unread: unreadInfo[feed.id] ? unreadInfo[feed.id] : 0,
-      }));
-      const groupsWithUnread = groupResponse.data.map((group) => {
-        const unreadCount = feedsWithUnread.reduce((total, feed) => {
-          if (feed.category.id === group.id) {
-            return total + feed.unread;
-          } else {
-            return total;
-          }
-        }, 0);
-        const feedCount = feedsWithUnread.reduce((total, feed) => {
-          if (feed.category.id === group.id) {
-            return total + 1;
-          } else {
-            return total;
-          }
-        }, 0);
+        if (feedResponse && unreadResponse && groupResponse) {
+            const unreadInfo = unreadResponse.data.unreads;
+            const feedsWithUnread = feedResponse.data.map((feed) => ({
+                ...feed,
+                unread: unreadInfo[feed.id] || 0,
+            }));
 
-        return {
-          ...group,
-          unread: unreadCount,
-          feed: feedCount,
-        };
-      });
-      set({ feeds: _.orderBy(feedsWithUnread, ["title"], ["asc"]) });
-      set({ groups: _.orderBy(groupsWithUnread, ["title"], ["asc"]) });
-      set({ loading: false });
-    }
-  },
-  updateFeedUnreadCount: (feed_id, newStatus) => {
-    set((state) => {
-      const updatedFeeds = state.feeds.map((feed) =>
-        feed.id === feed_id
-          ? {
-              ...feed,
-              unread: newStatus === "read" ? feed.unread - 1 : feed.unread + 1,
-            }
-          : feed,
-      );
-      return { feeds: updatedFeeds };
-    });
-  },
-  updateGroupUnreadCount: (group_id, newStatus) => {
-    set((state) => {
-      const updatedGroups = state.groups.map((group) =>
-        group.id === group_id
-          ? {
-              ...group,
-              unread:
-                newStatus === "read" ? group.unread - 1 : group.unread + 1,
-            }
-          : group,
-      );
-      return { groups: updatedGroups };
-    });
-  },
+            const groupsWithUnread = groupResponse.data.map((group) => {
+                let unreadCount = 0;
+                let feedCount = 0;
+
+                feedsWithUnread.forEach((feed) => {
+                    if (feed.category.id === group.id) {
+                        unreadCount += feed.unread;
+                        feedCount += 1;
+                    }
+                });
+
+                return {
+                    ...group,
+                    unread: unreadCount,
+                    feed: feedCount,
+                };
+            });
+
+            const totalUnreadCount = groupsWithUnread.reduce((sum, group) => sum + group.unread, 0);
+
+            set({feeds: _.orderBy(feedsWithUnread, ["title"], ["asc"])});
+            set({groups: _.orderBy(groupsWithUnread, ["title"], ["asc"])});
+            set({loading: false});
+            set({totalUnread: totalUnreadCount});
+            set({initDataCompleted: true});
+        }
+    },
+
+    updateFeedUnread: (feedId, status) => {
+        set((state) => {
+            const updatedFeeds = state.feeds.map((feed) =>
+                feed.id === feedId
+                    ? {
+                        ...feed,
+                        unread: status === "read" ? Math.max(0, feed.unread - 1) : feed.unread + 1,
+                    }
+                    : feed,
+            );
+            return {feeds: updatedFeeds};
+        });
+    },
+
+    updateGroupUnread: (groupId, status) => {
+        set((state) => {
+            const updatedGroups = state.groups.map((group) =>
+                group.id === groupId
+                    ? {
+                        ...group,
+                        unread:
+                            status === "read" ? Math.max(0, group.unread - 1) : group.unread + 1,
+                    }
+                    : group,
+            );
+            const newTotalUnread = updatedGroups.reduce((sum, group) => sum + group.unread, 0);
+            return {groups: updatedGroups, totalUnread: newTotalUnread};
+        });
+    },
 }));
 
 export default function App() {
-  const navigate = useNavigate();
-  const [collapsed, setCollapsed] = useState(false);
-  const [theme, setTheme] = useState(localStorage.getItem("theme") || "light");
-  const [visible, setVisible] = useState(false);
-  const feeds = useStore((state) => state.feeds);
-  const groups = useStore((state) => state.groups);
-  const loading = useStore((state) => state.loading);
-  const initData = useStore((state) => state.initData);
-  const [feedModalVisible, setFeedModalVisible] = useState(false);
-  const [feedModalLoading, setFeedModalLoading] = useState(false);
-  const [feedForm] = Form.useForm();
-  let path = useLocation().pathname;
-  useEffect(() => {
-    console.log(path);
-    console.log(
-      path.substring(1).indexOf("/") === -1
-        ? path
-        : path.substring(0, path.substring(1).indexOf("/") + 1),
-    );
-  }, [path]);
-  useEffect(() => {
-    initData();
-    initTheme();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    const navigate = useNavigate();
+    const [collapsed, setCollapsed] = useState(false);
+    const [theme, setTheme] = useState(localStorage.getItem("theme") || "light");
+    const [visible, setVisible] = useState(false);
+    const feeds = useStore((state) => state.feeds);
+    const groups = useStore((state) => state.groups);
+    const loading = useStore((state) => state.loading);
+    const initData = useStore((state) => state.initData);
+    const [feedModalVisible, setFeedModalVisible] = useState(false);
+    const [feedModalLoading, setFeedModalLoading] = useState(false);
+    const [feedForm] = Form.useForm();
+    let path = useLocation().pathname;
 
-  function handelToggle() {
-    if (theme === "light") {
-      document.body.setAttribute("arco-theme", "dark");
-      setTheme("dark");
-      localStorage.setItem("theme", "dark");
-    } else {
-      document.body.removeAttribute("arco-theme");
-      setTheme("light");
-      localStorage.setItem("theme", "light");
-    }
-  }
-
-  function initTheme() {
-    if (theme === "dark") {
-      document.body.setAttribute("arco-theme", "dark");
-    } else {
-      document.body.removeAttribute("arco-theme");
-    }
-  }
-
-  function handelCollapse(collapse) {
-    setCollapsed(collapse);
-  }
-
-  async function handelAddFeed(feed_url, group_id, is_full_text) {
-    setFeedModalLoading(true);
-    const response = await addFeed(feed_url, group_id, is_full_text);
-    if (response) {
-      initData();
-      Message.success("Success");
-      setFeedModalVisible(false);
-    }
-    setFeedModalLoading(false);
-    feedForm.resetFields();
-  }
-
-  function handelLogout() {
-    localStorage.removeItem("server");
-    localStorage.removeItem("token");
-    localStorage.removeItem("theme");
-    document.body.removeAttribute("arco-theme");
-    navigate("/login");
-    Message.success("logout");
-  }
-
-  return (
-    <div
-      className="app"
-      style={{ display: "flex", backgroundColor: "var(--color-bg-1)" }}
-    >
-      <div
-        className="header"
-        style={{
-          borderBottom: "1px solid var(--color-border-2)",
-          display: "flex",
-          flexDirection: "row",
-          justifyContent: "space-between",
-          alignItems: "center",
-          position: "fixed",
-          width: "100%",
-          height: "48px",
-          zIndex: "999",
-          backgroundColor: "var(--color-bg-1)",
-        }}
-      >
-        <div
-          className="brand"
-          style={{ marginLeft: "20px", display: "flex", alignItems: "center" }}
-        >
-          <IconBook
-            style={{
-              fontSize: 32,
-              color: "rgb(var(--primary-6))",
-              marginRight: "5px",
-            }}
-          />
-          <Typography.Title heading={5} style={{ margin: "0" }}>
-            Reactflux
-          </Typography.Title>
-        </div>
-        <div className="button-group" style={{ marginRight: "20px" }}>
-          <Space size={16}>
-            <Tooltip content="Add feed">
-              <Button
-                shape="circle"
-                size="small"
-                type="primary"
-                icon={<IconPlus />}
-                onClick={() => setFeedModalVisible(true)}
-              />
-            </Tooltip>
-            <Tooltip
-              content={
-                theme === "dark"
-                  ? "Switch to light mode"
-                  : "Switch to dark mode"
-              }
-            >
-              <Button
-                shape="circle"
-                size="small"
-                icon={theme === "dark" ? <IconSunFill /> : <IconMoonFill />}
-                onClick={() => handelToggle()}
-              ></Button>
-            </Tooltip>
-
-            <Dropdown
-              droplist={
-                <Menu>
-                  <Menu.Item key="0" onClick={() => setVisible(true)}>
-                    <IconSettings
-                      style={{
-                        marginRight: 8,
-                        fontSize: 16,
-                        transform: "translateY(1px)",
-                      }}
-                    />
-                    Settings
-                  </Menu.Item>
-                  <Menu.Item key="1" onClick={handelLogout}>
-                    <IconPoweroff
-                      style={{
-                        marginRight: 8,
-                        fontSize: 16,
-                        transform: "translateY(1px)",
-                      }}
-                    />
-                    Logout
-                  </Menu.Item>
-                </Menu>
-              }
-              trigger="click"
-              position="br"
-            >
-              <Avatar size={28} style={{ cursor: "pointer" }}>
-                <IconUser />
-              </Avatar>
-            </Dropdown>
-          </Space>
-        </div>
-      </div>
-      <Sider
-        className="sidebar"
-        trigger={null}
-        breakpoint="lg"
-        onCollapse={(collapse) => handelCollapse(collapse)}
-        collapsed={collapsed}
-        collapsible
-        style={{
-          height: "calc(100% - 49px)",
-          borderRight: "1px solid var(--color-border-2)",
-          position: "fixed",
-          top: "49px",
-          zIndex: "999",
-        }}
-      >
-        <Menu
-          style={{ width: 200, height: "100%" }}
-          onCollapseChange={() => setCollapsed(!collapsed)}
-          collapse={collapsed}
-          autoOpen
-          hasCollapseButton
-          defaultOpenKeys={[
+    useEffect(() => {
+        console.log(path);
+        console.log(
             path.substring(1).indexOf("/") === -1
-              ? path
-              : path.substring(0, path.substring(1).indexOf("/") + 1),
-          ]}
-          defaultSelectedKeys={[path]}
-        >
-          <Menu.Item key={`/`} onClick={() => navigate("/")}>
-            <IconList />
-            <span style={{ fontWeight: 500 }}>ARTICLES</span>
-          </Menu.Item>
-          {/*{collapsed ? null : <Divider style={{ margin: "4px" }} />}*/}
-          <SubMenu
-            key={`/group`}
-            title={
-              <>
-                <IconApps />
-                <span style={{ fontWeight: 500 }}>GROUPS</span>
-              </>
-            }
-          >
-            <Skeleton loading={loading} animation={true} text={{ rows: 6 }} />
-            {!loading
-              ? groups.map((group) => (
-                  <MenuItem
-                    key={`/group/${group.id}`}
-                    onClick={() => navigate(`/group/${group.id}`)}
-                  >
-                    <div
-                      style={{
-                        display: "flex",
-                        justifyContent: "space-between",
-                        alignItems: "center",
-                      }}
-                    >
-                      <Typography.Ellipsis
-                        expandable={false}
-                        showTooltip={true}
-                        style={{ width: group.unread !== 0 ? "80%" : "100%" }}
-                      >
-                        {group.title.toUpperCase()}
-                      </Typography.Ellipsis>
-                      <Typography.Ellipsis
-                        expandable={false}
-                        showTooltip={true}
-                        style={{
-                          width: "20%",
-                          color: "var(--color-text-4)",
-                          display: "flex",
-                          justifyContent: "flex-end",
-                        }}
-                      >
-                        {group.unread === 0 ? "" : group.unread}
-                      </Typography.Ellipsis>
-                    </div>
-                  </MenuItem>
-                ))
-              : null}
-          </SubMenu>
-          {/*{collapsed ? null : <Divider style={{ margin: "4px" }} />}*/}
-          <SubMenu
-            key={`/feed`}
-            title={
-              <>
-                <IconFile />
-                <span style={{ fontWeight: 500 }}>FEEDS</span>
-              </>
-            }
-          >
-            <Skeleton loading={loading} animation={true} text={{ rows: 6 }} />
-            {!loading && feeds.length > 0
-              ? feeds.map((feed) => (
-                  <MenuItem
-                    key={`/feed/${feed.id}`}
-                    onClick={() => navigate(`/feed/${feed.id}`)}
-                  >
-                    <div
-                      style={{
-                        display: "flex",
-                        justifyContent: "space-between",
-                        alignItems: "center",
-                      }}
-                    >
-                      <Typography.Ellipsis
-                        expandable={false}
-                        showTooltip={true}
-                        style={{
-                          width: feed.unread !== 0 ? "80%" : "100%",
-                        }}
-                      >
-                        {feed.title.toUpperCase()}{" "}
-                      </Typography.Ellipsis>
-                      <Typography.Ellipsis
-                        expandable={false}
-                        showTooltip={true}
-                        style={{
-                          width: "20%",
-                          color: "var(--color-text-4)",
-                          display: "flex",
-                          justifyContent: "flex-end",
-                        }}
-                      >
-                        {feed.unread === 0 ? "" : feed.unread}
-                      </Typography.Ellipsis>
-                    </div>
-                  </MenuItem>
-                ))
-              : null}
-          </SubMenu>
-        </Menu>
-      </Sider>
-      <div
-        className="article-list"
-        style={{
-          backgroundColor: "var(--color-fill-1)",
-          paddingTop: "49px",
-          paddingLeft: collapsed ? "48px" : "200px",
-          height: "calc(100vh - 49px)",
-          display: "flex",
-          transition: "all 0.1s linear",
-          width: collapsed ? "calc(100% - 49px)" : "calc(100% - 200px)",
-        }}
-      >
-        <Outlet />
-        <Modal
-          title="Settings"
-          visible={visible}
-          alignCenter={false}
-          footer={null}
-          unmountOnExit
-          style={{ width: "720px", top: "10%" }}
-          onCancel={() => {
-            setVisible(false);
+                ? path
+                : path.substring(0, path.substring(1).indexOf("/") + 1),
+        );
+    }, [path]);
+
+    const initTheme = () => {
+        if (theme === "dark") {
+            document.body.setAttribute("arco-theme", "dark");
+        } else {
+            document.body.removeAttribute("arco-theme");
+        }
+    };
+
+    useEffect(() => {
+        initData();
+        initTheme();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const handelToggle = () => {
+        if (theme === "light") {
+            document.body.setAttribute("arco-theme", "dark");
+            setTheme("dark");
+            localStorage.setItem("theme", "dark");
+        } else {
+            document.body.removeAttribute("arco-theme");
+            setTheme("light");
+            localStorage.setItem("theme", "light");
+        }
+    };
+
+    const handelCollapse = collapse => {
+        setCollapsed(collapse);
+    };
+
+    const handelAddFeed = async (feed_url, group_id, is_full_text) => {
+        setFeedModalLoading(true);
+        const response = await addFeed(feed_url, group_id, is_full_text);
+        if (response) {
             initData();
-          }}
-          autoFocus={false}
-          focusLock={true}
-        >
-          <Settings />
-        </Modal>
-        <Modal
-          title="Add Feed"
-          visible={feedModalVisible}
-          unmountOnExit
-          style={{ width: "400px" }}
-          onOk={feedForm.submit}
-          confirmLoading={feedModalLoading}
-          onCancel={() => {
+            Message.success("Success");
             setFeedModalVisible(false);
-            feedForm.resetFields();
-          }}
+        }
+        setFeedModalLoading(false);
+        feedForm.resetFields();
+    };
+
+    const handelLogout = () => {
+        localStorage.removeItem("server");
+        localStorage.removeItem("token");
+        localStorage.removeItem("theme");
+        document.body.removeAttribute("arco-theme");
+        navigate("/login");
+        Message.success("logout");
+    };
+
+    return (
+        <div
+            className="app"
+            style={{display: "flex", backgroundColor: "var(--color-bg-1)"}}
         >
-          <Form
-            form={feedForm}
-            layout="vertical"
-            onChange={(value, values) => console.log(value, values)}
-            onSubmit={(values) =>
-              handelAddFeed(values.url, values.group, values.crawler)
-            }
-            labelCol={{
-              span: 7,
-            }}
-            wrapperCol={{
-              span: 17,
-            }}
-          >
-            <Form.Item
-              label="Feed url"
-              field="url"
-              rules={[{ required: true }]}
+            <div
+                className="header"
+                style={{
+                    borderBottom: "1px solid var(--color-border-2)",
+                    display: "flex",
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    position: "fixed",
+                    width: "100%",
+                    height: "48px",
+                    zIndex: "999",
+                    backgroundColor: "var(--color-bg-1)",
+                }}
             >
-              <Input placeholder="Please input feed url" />
-            </Form.Item>
-            <Form.Item
-              label="Group"
-              required
-              field="group"
-              rules={[{ required: true }]}
+                <div
+                    className="brand"
+                    style={{marginLeft: "20px", display: "flex", alignItems: "center"}}
+                >
+                    <IconBook
+                        style={{
+                            fontSize: 32,
+                            color: "rgb(var(--primary-6))",
+                            marginRight: "5px",
+                        }}
+                    />
+                    <Typography.Title heading={5} style={{margin: "0"}}>
+                        Reactflux
+                    </Typography.Title>
+                </div>
+                <div className="button-group" style={{marginRight: "20px"}}>
+                    <Space size={16}>
+                        <Tooltip content="Add feed">
+                            <Button
+                                shape="circle"
+                                size="small"
+                                type="primary"
+                                icon={<IconPlus/>}
+                                onClick={() => setFeedModalVisible(true)}
+                            />
+                        </Tooltip>
+                        <Tooltip
+                            content={
+                                theme === "dark"
+                                    ? "Switch to light mode"
+                                    : "Switch to dark mode"
+                            }
+                        >
+                            <Button
+                                shape="circle"
+                                size="small"
+                                icon={theme === "dark" ? <IconSunFill/> : <IconMoonFill/>}
+                                onClick={() => handelToggle()}
+                            ></Button>
+                        </Tooltip>
+
+                        <Dropdown
+                            droplist={
+                                <Menu>
+                                    <Menu.Item key="0" onClick={() => setVisible(true)}>
+                                        <IconSettings
+                                            style={{
+                                                marginRight: 8,
+                                                fontSize: 16,
+                                                transform: "translateY(1px)",
+                                            }}
+                                        />
+                                        Settings
+                                    </Menu.Item>
+                                    <Menu.Item key="1" onClick={handelLogout}>
+                                        <IconPoweroff
+                                            style={{
+                                                marginRight: 8,
+                                                fontSize: 16,
+                                                transform: "translateY(1px)",
+                                            }}
+                                        />
+                                        Logout
+                                    </Menu.Item>
+                                </Menu>
+                            }
+                            trigger="click"
+                            position="br"
+                        >
+                            <Avatar size={28} style={{cursor: "pointer"}}>
+                                <IconUser/>
+                            </Avatar>
+                        </Dropdown>
+                    </Space>
+                </div>
+            </div>
+            <Sider
+                className="sidebar"
+                trigger={null}
+                breakpoint="lg"
+                onCollapse={(collapse) => handelCollapse(collapse)}
+                collapsed={collapsed}
+                collapsible
+                style={{
+                    height: "calc(100% - 49px)",
+                    borderRight: "1px solid var(--color-border-2)",
+                    position: "fixed",
+                    top: "49px",
+                    zIndex: "999",
+                }}
             >
-              <Select placeholder="Please select">
-                {groups.map((group) => (
-                  <Select.Option key={group.id} value={group.id}>
-                    {group.title}
-                  </Select.Option>
-                ))}
-              </Select>
-            </Form.Item>
-            <Form.Item
-              label="Fetch original content"
-              initialValue={false}
-              field="crawler"
-              style={{ marginBottom: 0 }}
-              triggerPropName="checked"
-              rules={[{ type: "boolean" }]}
+                <Menu
+                    style={{width: 200, height: "100%"}}
+                    onCollapseChange={() => setCollapsed(!collapsed)}
+                    collapse={collapsed}
+                    autoOpen
+                    hasCollapseButton
+                    defaultOpenKeys={[
+                        path.substring(1).indexOf("/") === -1
+                            ? path
+                            : path.substring(0, path.substring(1).indexOf("/") + 1),
+                    ]}
+                    defaultSelectedKeys={[path]}
+                >
+                    <Menu.Item key={`/`} onClick={() => navigate("/")}>
+                        <IconList/>
+                        <span style={{fontWeight: 500}}>ARTICLES</span>
+                    </Menu.Item>
+                    {/*{collapsed ? null : <Divider style={{ margin: "4px" }} />}*/}
+                    <SubMenu
+                        key={`/group`}
+                        title={
+                            <>
+                                <IconApps/>
+                                <span style={{fontWeight: 500}}>GROUPS</span>
+                            </>
+                        }
+                    >
+                        <Skeleton loading={loading} animation={true} text={{rows: 6}}/>
+                        {loading ? null : groups.map((group) => (
+                            <MenuItem
+                                key={`/group/${group.id}`}
+                                onClick={() => navigate(`/group/${group.id}`)}
+                            >
+                                <div
+                                    style={{
+                                        display: "flex",
+                                        justifyContent: "space-between",
+                                        alignItems: "center",
+                                    }}
+                                >
+                                    <Typography.Ellipsis
+                                        expandable={false}
+                                        showTooltip={true}
+                                        style={{width: group.unread !== 0 ? "80%" : "100%"}}
+                                    >
+                                        {group.title.toUpperCase()}
+                                    </Typography.Ellipsis>
+                                    <Typography.Ellipsis
+                                        expandable={false}
+                                        showTooltip={true}
+                                        style={{
+                                            width: "20%",
+                                            color: "var(--color-text-4)",
+                                            display: "flex",
+                                            justifyContent: "flex-end",
+                                        }}
+                                    >
+                                        {group.unread === 0 ? "" : group.unread}
+                                    </Typography.Ellipsis>
+                                </div>
+                            </MenuItem>
+                        ))}
+                    </SubMenu>
+                    {/*{collapsed ? null : <Divider style={{ margin: "4px" }} />}*/}
+                    <SubMenu
+                        key={`/feed`}
+                        title={
+                            <>
+                                <IconFile/>
+                                <span style={{fontWeight: 500}}>FEEDS</span>
+                            </>
+                        }
+                    >
+                        <Skeleton loading={loading} animation={true} text={{rows: 6}}/>
+                        {!loading && feeds.length > 0
+                            ? feeds.map((feed) => (
+                                <MenuItem
+                                    key={`/feed/${feed.id}`}
+                                    onClick={() => navigate(`/feed/${feed.id}`)}
+                                >
+                                    <div
+                                        style={{
+                                            display: "flex",
+                                            justifyContent: "space-between",
+                                            alignItems: "center",
+                                        }}
+                                    >
+                                        <Typography.Ellipsis
+                                            expandable={false}
+                                            showTooltip={true}
+                                            style={{
+                                                width: feed.unread !== 0 ? "80%" : "100%",
+                                            }}
+                                        >
+                                            {feed.title.toUpperCase()}{" "}
+                                        </Typography.Ellipsis>
+                                        <Typography.Ellipsis
+                                            expandable={false}
+                                            showTooltip={true}
+                                            style={{
+                                                width: "20%",
+                                                color: "var(--color-text-4)",
+                                                display: "flex",
+                                                justifyContent: "flex-end",
+                                            }}
+                                        >
+                                            {feed.unread === 0 ? "" : feed.unread}
+                                        </Typography.Ellipsis>
+                                    </div>
+                                </MenuItem>
+                            ))
+                            : null}
+                    </SubMenu>
+                </Menu>
+            </Sider>
+            <div
+                className="article-list"
+                style={{
+                    backgroundColor: "var(--color-fill-1)",
+                    paddingTop: "49px",
+                    paddingLeft: collapsed ? "48px" : "200px",
+                    height: "calc(100vh - 49px)",
+                    display: "flex",
+                    transition: "all 0.1s linear",
+                    width: collapsed ? "calc(100% - 49px)" : "calc(100% - 200px)",
+                }}
             >
-              <Switch />
-            </Form.Item>
-          </Form>
-        </Modal>
-      </div>
-    </div>
-  );
+                <Outlet/>
+                <Modal
+                    title="Settings"
+                    visible={visible}
+                    alignCenter={false}
+                    footer={null}
+                    unmountOnExit
+                    style={{width: "720px", top: "10%"}}
+                    onCancel={() => {
+                        setVisible(false);
+                        initData();
+                    }}
+                    autoFocus={false}
+                    focusLock={true}
+                >
+                    <Settings/>
+                </Modal>
+                <Modal
+                    title="Add Feed"
+                    visible={feedModalVisible}
+                    unmountOnExit
+                    style={{width: "400px"}}
+                    onOk={feedForm.submit}
+                    confirmLoading={feedModalLoading}
+                    onCancel={() => {
+                        setFeedModalVisible(false);
+                        feedForm.resetFields();
+                    }}
+                >
+                    <Form
+                        form={feedForm}
+                        layout="vertical"
+                        onChange={(value, values) => console.log(value, values)}
+                        onSubmit={(values) =>
+                            handelAddFeed(values.url, values.group, values.crawler)
+                        }
+                        labelCol={{
+                            span: 7,
+                        }}
+                        wrapperCol={{
+                            span: 17,
+                        }}
+                    >
+                        <Form.Item
+                            label="Feed url"
+                            field="url"
+                            rules={[{required: true}]}
+                        >
+                            <Input placeholder="Please input feed url"/>
+                        </Form.Item>
+                        <Form.Item
+                            label="Group"
+                            required
+                            field="group"
+                            rules={[{required: true}]}
+                        >
+                            <Select placeholder="Please select">
+                                {groups.map((group) => (
+                                    <Select.Option key={group.id} value={group.id}>
+                                        {group.title}
+                                    </Select.Option>
+                                ))}
+                            </Select>
+                        </Form.Item>
+                        <Form.Item
+                            label="Fetch original content"
+                            initialValue={false}
+                            field="crawler"
+                            style={{marginBottom: 0}}
+                            triggerPropName="checked"
+                            rules={[{type: "boolean"}]}
+                        >
+                            <Switch/>
+                        </Form.Item>
+                    </Form>
+                </Modal>
+            </div>
+        </div>
+    );
 }
 
-export { useStore };
+export {useStore};

--- a/src/App.js
+++ b/src/App.js
@@ -120,6 +120,8 @@ const useStore = create((set) => ({
 
 export default function App() {
     const navigate = useNavigate();
+    const location = useLocation();
+    const [selectedKeys, setSelectedKeys] = useState([]);
     const [collapsed, setCollapsed] = useState(false);
     const [theme, setTheme] = useState(localStorage.getItem("theme") || "light");
     const [visible, setVisible] = useState(false);
@@ -130,7 +132,11 @@ export default function App() {
     const [feedModalVisible, setFeedModalVisible] = useState(false);
     const [feedModalLoading, setFeedModalLoading] = useState(false);
     const [feedForm] = Form.useForm();
-    let path = useLocation().pathname;
+    const path = location.pathname;
+
+    useEffect(() => {
+        setSelectedKeys([location.pathname]);
+    }, [location]);
 
     useEffect(() => {
         console.log(path);
@@ -304,6 +310,7 @@ export default function App() {
                 }}
             >
                 <Menu
+                    selectedKeys={selectedKeys}
                     style={{width: 200, height: "100%"}}
                     onCollapseChange={() => setCollapsed(!collapsed)}
                     collapse={collapsed}

--- a/src/Feed.js
+++ b/src/Feed.js
@@ -1,45 +1,43 @@
-import { useParams } from "react-router-dom";
-import { Message } from "@arco-design/web-react";
+import {useParams} from "react-router-dom";
+import {Message} from "@arco-design/web-react";
 import Content from "./components/Content";
-import { thunder } from "./apis/axios";
+import {thunder} from "./apis/axios";
 
 export default function Feed() {
-  const { f_id } = useParams();
+    const {f_id} = useParams();
 
-  async function getFeedEntries(offset = 0) {
-    const base_url = `/v1/feeds/${f_id}/entries?order=published_at&direction=desc`;
-    const url = offset ? `${base_url}&offset=${offset}` : base_url;
-    try {
-      const response = await thunder.request({ method: "get", url });
-      console.log(response);
-      return response;
-    } catch (error) {
-      console.error(error);
-      Message.error(error.message);
-    }
-  }
+    const getFeedEntries = async (offset = 0) => {
+        const base_url = `/v1/feeds/${f_id}/entries?order=published_at&direction=desc`;
+        const url = offset ? `${base_url}&offset=${offset}` : base_url;
+        try {
+            const response = await thunder.request({method: "get", url});
+            console.log(response);
+            return response;
+        } catch (error) {
+            console.error(error);
+            Message.error(error.message);
+        }
+    };
 
-  async function markAllAsRead() {
-    try {
-      const response = await thunder.request({
-        method: "put",
-        url: `/v1/feeds/${f_id}/mark-all-as-read`,
-      });
-      console.log(response);
-      return response;
-    } catch (error) {
-      console.error(error);
-      Message.error(error.message);
-    }
-  }
+    const markAllAsRead = async () => {
+        try {
+            const response = await thunder.request({
+                method: "put",
+                url: `/v1/feeds/${f_id}/mark-all-as-read`,
+            });
+            console.log(response);
+            return response;
+        } catch (error) {
+            console.error(error);
+            Message.error(error.message);
+        }
+    };
 
-  return (
-    <>
-      <Content
-        info={{ from: "feed", id: f_id }}
-        getEntries={getFeedEntries}
-        markAllAsRead={markAllAsRead}
-      />
-    </>
-  );
+    return (
+        <Content
+            info={{from: "feed", id: f_id}}
+            getEntries={getFeedEntries}
+            markAllAsRead={markAllAsRead}
+        />
+    );
 }

--- a/src/Group.js
+++ b/src/Group.js
@@ -1,46 +1,44 @@
-import { useParams } from "react-router-dom";
-import { Message } from "@arco-design/web-react";
+import {useParams} from "react-router-dom";
+import {Message} from "@arco-design/web-react";
 import Content from "./components/Content";
-import { thunder } from "./apis/axios";
+import {thunder} from "./apis/axios";
 
 export default function Group() {
-  const { c_id } = useParams();
+    const {c_id} = useParams();
 
-  async function getGroupEntries(offset = 0) {
-    const base_url = `/v1/categories/${c_id}/entries?order=published_at&direction=desc`;
-    const url = offset ? `${base_url}&offset=${offset}` : base_url;
+    const getGroupEntries = async (offset = 0) => {
+        const base_url = `/v1/categories/${c_id}/entries?order=published_at&direction=desc`;
+        const url = offset ? `${base_url}&offset=${offset}` : base_url;
 
-    try {
-      const response = await thunder.request({ method: "get", url });
-      console.log(response);
-      return response;
-    } catch (error) {
-      console.error(error);
-      Message.error(error.message);
-    }
-  }
+        try {
+            const response = await thunder.request({method: "get", url});
+            console.log(response);
+            return response;
+        } catch (error) {
+            console.error(error);
+            Message.error(error.message);
+        }
+    };
 
-  async function markGroupAsRead() {
-    try {
-      const response = await thunder.request({
-        method: "put",
-        url: `/v1/categories/${c_id}/mark-all-as-read`,
-      });
-      console.log(response);
-      return response;
-    } catch (error) {
-      console.error(error);
-      Message.error(error.message);
-    }
-  }
+    const markGroupAsRead = async () => {
+        try {
+            const response = await thunder.request({
+                method: "put",
+                url: `/v1/categories/${c_id}/mark-all-as-read`,
+            });
+            console.log(response);
+            return response;
+        } catch (error) {
+            console.error(error);
+            Message.error(error.message);
+        }
+    };
 
-  return (
-    <>
-      <Content
-        info={{ from: "group", id: c_id }}
-        getEntries={getGroupEntries}
-        markAllAsRead={markGroupAsRead}
-      />
-    </>
-  );
+    return (
+        <Content
+            info={{from: "group", id: c_id}}
+            getEntries={getGroupEntries}
+            markAllAsRead={markGroupAsRead}
+        />
+    );
 }

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -1,194 +1,207 @@
-import { thunder } from "./axios";
-import { Message } from "@arco-design/web-react";
+import {thunder} from "./axios";
+import {Message} from "@arco-design/web-react";
 
 export async function updateEntry(entry) {
-  const newStatus = entry.status === "read" ? "unread" : "read";
-  try {
-    const response = await thunder.request({
-      method: "put",
-      url: `/v1/entries`,
-      data: { entry_ids: [entry.id], status: newStatus },
-    });
-    console.log(response);
-    return response;
-  } catch (error) {
-    console.error(error);
-    Message.error(error.message);
-  }
+    const newStatus = entry.status === "read" ? "unread" : "read";
+    try {
+        const response = await thunder.request({
+            method: "put",
+            url: `/v1/entries`,
+            data: {entry_ids: [entry.id], status: newStatus},
+        });
+        console.log(response);
+        return response;
+    } catch (error) {
+        console.error(error);
+        Message.error(error.message);
+    }
+}
+
+export async function starEntry(entry) {
+    // PUT /v1/entries/1234/bookmark
+    try {
+        return await thunder.request({
+            method: "put",
+            url: `/v1/entries/${entry.id}/bookmark`,
+        });
+    } catch (error) {
+        console.error(error);
+        Message.error(error.message);
+    }
 }
 
 export async function getCurrentUser() {
-  try {
-    const response = await thunder.request({
-      method: "get",
-      url: `/v1/me`,
-    });
-    console.log(response);
-    return response;
-  } catch (error) {
-    console.error(error);
-    Message.error(error.message);
-  }
+    try {
+        const response = await thunder.request({
+            method: "get",
+            url: `/v1/me`,
+        });
+        console.log(response);
+        return response;
+    } catch (error) {
+        console.error(error);
+        Message.error(error.message);
+    }
 }
 
 export async function clickEntryList(entry) {
-  try {
-    const response = await thunder.request({
-      method: "put",
-      url: `/v1/entries`,
-      data: { entry_ids: [entry.id], status: "read" },
-    });
-    console.log(response);
-    return response;
-  } catch (error) {
-    console.error(error);
-    Message.error(error.message);
-  }
+    try {
+        const response = await thunder.request({
+            method: "put",
+            url: `/v1/entries`,
+            data: {entry_ids: [entry.id], status: "read"},
+        });
+        console.log(response);
+        return response;
+    } catch (error) {
+        console.error(error);
+        Message.error(error.message);
+    }
 }
 
 export async function getUnreadInfo() {
-  try {
-    const response = await thunder.request({
-      method: "get",
-      url: `/v1/feeds/counters`,
-    });
-    console.log(response);
-    return response;
-  } catch (error) {
-    console.error(error);
-    Message.error(error.message);
-  }
+    try {
+        const response = await thunder.request({
+            method: "get",
+            url: `/v1/feeds/counters`,
+        });
+        console.log(response);
+        return response;
+    } catch (error) {
+        console.error(error);
+        Message.error(error.message);
+    }
 }
 
 export async function getFeeds() {
-  try {
-    const response = await thunder.request({
-      method: "get",
-      url: `/v1/feeds`,
-    });
-    console.log(response);
-    return response;
-  } catch (error) {
-    console.error(error);
-    Message.error(error.message);
-  }
+    try {
+        const response = await thunder.request({
+            method: "get",
+            url: `/v1/feeds`,
+        });
+        console.log(response);
+        return response;
+    } catch (error) {
+        console.error(error);
+        Message.error(error.message);
+    }
 }
 
 export async function getGroups() {
-  try {
-    const response = await thunder.request({
-      method: "get",
-      url: `/v1/categories`,
-    });
-    console.log(response);
-    return response;
-  } catch (error) {
-    console.error(error);
-    Message.error(error.message);
-  }
+    try {
+        const response = await thunder.request({
+            method: "get",
+            url: `/v1/categories`,
+        });
+        console.log(response);
+        return response;
+    } catch (error) {
+        console.error(error);
+        Message.error(error.message);
+    }
 }
 
 export async function delGroup(id) {
-  try {
-    const response = await thunder.request({
-      method: "delete",
-      url: `/v1/categories/${id}`,
-    });
-    console.log(response);
-    return response;
-  } catch (error) {
-    console.error(error);
-    Message.error(error.message);
-    throw error;
-  }
+    try {
+        const response = await thunder.request({
+            method: "delete",
+            url: `/v1/categories/${id}`,
+        });
+        console.log(response);
+        return response;
+    } catch (error) {
+        console.error(error);
+        Message.error(error.message);
+        throw error;
+    }
 }
 
 export async function addGroup(title) {
-  try {
-    const response = await thunder.request({
-      method: "post",
-      url: `/v1/categories`,
-      headers: {
-        "Content-Type": "application/json",
-      },
-      data: { title: title },
-    });
-    console.log(response);
-    return response;
-  } catch (error) {
-    console.error(error);
-    Message.error(error.response.data.error_message || error.message);
-  }
+    try {
+        const response = await thunder.request({
+            method: "post",
+            url: `/v1/categories`,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            data: {title: title},
+        });
+        console.log(response);
+        return response;
+    } catch (error) {
+        console.error(error);
+        Message.error(error.response.data.error_message || error.message);
+    }
 }
 
 export async function editGroup(id, newTitle) {
-  try {
-    const response = await thunder.request({
-      method: "put",
-      url: `/v1/categories/${id}`,
-      headers: {
-        "Content-Type": "application/json",
-      },
-      data: { title: newTitle },
-    });
-    console.log(response);
-    return response;
-  } catch (error) {
-    console.error(error);
-    Message.error(error.response.data.error_message || error.message);
-  }
+    try {
+        const response = await thunder.request({
+            method: "put",
+            url: `/v1/categories/${id}`,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            data: {title: newTitle},
+        });
+        console.log(response);
+        return response;
+    } catch (error) {
+        console.error(error);
+        Message.error(error.response.data.error_message || error.message);
+    }
 }
 
 export async function editFeed(feed_id, newTitle, group_id, is_full_text) {
-  try {
-    const response = await thunder.request({
-      method: "put",
-      url: `/v1/feeds/${feed_id}`,
-      headers: {
-        "Content-Type": "application/json",
-      },
-      data: { title: newTitle, category_id: group_id, crawler: is_full_text },
-    });
-    console.log(response);
-    return response;
-  } catch (error) {
-    console.error(error);
-    Message.error(error.response.data.error_message || error.message);
-  }
+    try {
+        const response = await thunder.request({
+            method: "put",
+            url: `/v1/feeds/${feed_id}`,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            data: {title: newTitle, category_id: group_id, crawler: is_full_text},
+        });
+        console.log(response);
+        return response;
+    } catch (error) {
+        console.error(error);
+        Message.error(error.response.data.error_message || error.message);
+    }
 }
 
 export async function deleteFeed(feed_id) {
-  try {
-    const response = await thunder.request({
-      method: "delete",
-      url: `/v1/feeds/${feed_id}`,
-    });
-    console.log(response);
-    return response;
-  } catch (error) {
-    console.error(error);
-    Message.error(error.response.data.error_message || error.message);
-  }
+    try {
+        const response = await thunder.request({
+            method: "delete",
+            url: `/v1/feeds/${feed_id}`,
+        });
+        console.log(response);
+        return response;
+    } catch (error) {
+        console.error(error);
+        Message.error(error.response.data.error_message || error.message);
+    }
 }
 
 export async function addFeed(feed_url, group_id, is_full_text) {
-  try {
-    const response = await thunder.request({
-      method: "post",
-      url: `/v1/feeds`,
-      headers: {
-        "Content-Type": "application/json",
-      },
-      data: {
-        feed_url: feed_url,
-        category_id: group_id,
-        crawler: is_full_text,
-      },
-    });
-    console.log(response);
-    return response;
-  } catch (error) {
-    console.error(error);
-    Message.error(error.response.data.error_message || error.message);
-  }
+    try {
+        const response = await thunder.request({
+            method: "post",
+            url: `/v1/feeds`,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            data: {
+                feed_url: feed_url,
+                category_id: group_id,
+                crawler: is_full_text,
+            },
+        });
+        console.log(response);
+        return response;
+    } catch (error) {
+        console.error(error);
+        Message.error(error.response.data.error_message || error.message);
+    }
 }

--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -1,556 +1,609 @@
 import classNames from "classnames";
-import { CSSTransition } from "react-transition-group";
-import { useStore } from "../App";
-import { useEffect, useRef, useState } from "react";
+import {CSSTransition} from "react-transition-group";
+import {useStore} from "../App";
+import {useEffect, useRef, useState} from "react";
 import {
-  Button,
-  Card,
-  Divider,
-  Radio,
-  Input,
-  Typography,
-  Skeleton,
-  Popconfirm,
-  Message,
-  Tooltip,
-  Select,
+    Button,
+    Card,
+    Divider,
+    Radio,
+    Input,
+    Typography,
+    Skeleton,
+    Popconfirm,
+    Message,
+    Tooltip,
+    Select,
 } from "@arco-design/web-react";
 import "./Content.css";
 import "./Transition.css";
 import dayjs from "dayjs";
 import {
-  IconArrowDown,
-  IconCheck,
-  IconEmpty,
-  IconEye,
-  IconEyeInvisible,
+    IconArrowDown,
+    IconCheck,
+    IconEmpty,
+    IconEye,
+    IconEyeInvisible,
 } from "@arco-design/web-react/icon";
 import ImageWithLazyLoading from "./ImageWithLazyLoading";
-import { updateEntry, clickEntryList } from "../apis";
+import {updateEntry, clickEntryList} from "../apis";
 
 const cards = [1, 2, 3];
 
-export default function Content({ info, getEntries, markAllAsRead }) {
-  const [offset, setOffset] = useState(0);
-  const [loadMoreVisible, setLoadMoreVisible] = useState(false);
-  const [entries, setEntries] = useState([]);
-  const [allEntries, setAllEntries] = useState([]);
-  const [activeContent, setActiveContent] = useState(null);
-  const [animation, setAnimation] = useState(null);
-  const [filterStatus, setFilterStatus] = useState("all");
-  const [filterType, setFilterType] = useState("0");
-  const [filterString, setFilterString] = useState("");
-  const [loading, setLoading] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const updateFeedUnreadCount = useStore(
-    (state) => state.updateFeedUnreadCount,
-  );
-  const updateGroupUnreadCount = useStore(
-    (state) => state.updateGroupUnreadCount,
-  );
-  const initData = useStore((state) => state.initData);
+export default function Content({info, getEntries, markAllAsRead}) {
+    const [total, setTotal] = useState(0);
+    const [offset, setOffset] = useState(0);
+    const [unreadCount, setUnreadCount] = useState(0);
+    const totalUnread = useStore(
+        (state) => state.totalUnread,
+    );
+    const initDataCompleted = useStore(
+        (state) => state.initDataCompleted,
+    );
+    const feeds = useStore((state) => state.feeds);
+    const groups = useStore((state) => state.groups);
+    const [loadMoreVisible, setLoadMoreVisible] = useState(false);
+    const [loadMoreUnreadVisible, setLoadMoreUnreadVisible] = useState(false);
+    const [entries, setEntries] = useState([]);
+    const [allEntries, setAllEntries] = useState([]);
+    const [activeContent, setActiveContent] = useState(null);
+    const [animation, setAnimation] = useState(null);
+    const [filterStatus, setFilterStatus] = useState("all");
+    const [filterType, setFilterType] = useState("0");
+    const [filterString, setFilterString] = useState("");
+    const [loading, setLoading] = useState(true);
+    const [loadingMore, setLoadingMore] = useState(false);
+    const updateFeedUnread = useStore(
+        (state) => state.updateFeedUnread,
+    );
+    const updateGroupUnread = useStore(
+        (state) => state.updateGroupUnread,
+    );
+    const initData = useStore((state) => state.initData);
 
-  const entryListRef = useRef(null);
-  const entryDetailRef = useRef(null);
-  const cardsRef = useRef(null);
+    const entryListRef = useRef(null);
+    const entryDetailRef = useRef(null);
+    const cardsRef = useRef(null);
 
-  useEffect(() => {
-    getArticleList();
-    setActiveContent(null);
-    entryListRef.current.scrollTo(0, 0);
-    entryDetailRef.current.scrollTo(0, 0);
-    setOffset(0);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [info]);
-
-  function getFirstImage(entry) {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(entry.content, "text/html");
-    const firstImg = doc.querySelector("img");
-    if (firstImg) {
-      entry.imgSrc = firstImg.getAttribute("src");
-    }
-    return entry;
-  }
-
-  function filterArticles(articles, status) {
-    return status === "all"
-      ? articles
-      : articles.filter((article) => article.status === status);
-  }
-
-  async function getArticleList() {
-    try {
-      setLoading(true);
-      const response = await getEntries();
-      if (response && response.data.entries) {
-        const fetchedArticles = response.data.entries.map(getFirstImage);
-        setAllEntries(fetchedArticles);
-
-        const filteredArticles = filterArticles(fetchedArticles, filterStatus);
-        setEntries(filteredArticles);
-        setLoadMoreVisible(fetchedArticles.length < response.data.total);
-      }
-    } catch (error) {
-      console.error("Error fetching articles:", error);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleLoadMore() {
-    try {
-      setLoadingMore(true);
-      const response = await getEntries(offset + 100);
-      setOffset(offset + 100);
-      if (response && response.data.entries) {
-        const updatedArticles = [...entries, ...response.data.entries].map(
-          getFirstImage,
-        );
-        setAllEntries(updatedArticles);
-
-        const filteredArticles = filterArticles(updatedArticles, filterStatus);
-        setEntries(filteredArticles);
-        setLoadMoreVisible(updatedArticles.length < response.data.total);
-      }
-    } catch (error) {
-      console.error("Error fetching more articles:", error);
-    } finally {
-      setLoadingMore(false);
-    }
-  }
-
-  function handelFilterEntry(filter_type, filter_status, filter_string) {
-    setFilterType(filter_type);
-    setFilterStatus(filter_status);
-    setFilterString(filter_string);
-    if (filter_type === "0") {
-      setEntries(
-        filter_status === "all"
-          ? allEntries.filter((entry) => entry.title.includes(filter_string))
-          : allEntries.filter(
-              (entry) =>
-                entry.title.includes(filter_string) &&
-                entry.status === filter_status,
-            ),
-      );
-    } else {
-      setEntries(
-        filter_status === "all"
-          ? allEntries.filter((entry) => entry.content.includes(filter_string))
-          : allEntries.filter(
-              (entry) =>
-                entry.content.includes(filter_string) &&
-                entry.status === filter_status,
-            ),
-      );
-    }
-  }
-
-  function handelUpdateEntry() {
-    const newStatus = activeContent.status === "read" ? "unread" : "read";
-    async function switchArticleStatus() {
-      const response = await updateEntry(activeContent);
-      if (response) {
-        setActiveContent({
-          ...activeContent,
-          status: newStatus,
-        });
-        updateFeedUnreadCount(activeContent.feed.id, newStatus);
-        updateGroupUnreadCount(activeContent.feed.category.id, newStatus);
-        setEntries(
-          entries.map((e) =>
-            e.id === activeContent.id
-              ? {
-                  ...e,
-                  status: newStatus,
-                }
-              : { ...e },
-          ),
-        );
-        setAllEntries(
-          allEntries.map((e) =>
-            e.id === activeContent.id
-              ? {
-                  ...e,
-                  status: newStatus,
-                }
-              : { ...e },
-          ),
-        );
-      }
-    }
-    switchArticleStatus();
-  }
-
-  function handelMarkAllAsRead() {
-    async function readAll() {
-      const response = await markAllAsRead();
-      response && Message.success("Success");
-      await initData();
-      setAllEntries(allEntries.map((e) => ({ ...e, status: "read" })));
-      setEntries(entries.map((e) => ({ ...e, status: "read" })));
-    }
-    readAll();
-  }
-
-  function handelClickEntryList(entry) {
-    async function clickCard() {
-      setAnimation(null);
-      const response = await clickEntryList(entry);
-      if (response) {
-        setAnimation(true);
-        setActiveContent({
-          ...entry,
-          status: "read",
-        });
-        if (entry.status === "unread") {
-          updateFeedUnreadCount(entry.feed.id, "read");
-          updateGroupUnreadCount(entry.feed.category.id, "read");
+    const updateUnreadCount = () => {
+        let count = 0;
+        if (info.from === "all") {
+            count = totalUnread;
+        } else if (info.from === "feed") {
+            const feed = feeds.find(
+                (feed) => feed.id.toString() === info.id,
+            );
+            count = feed ? feed.unread : 0;
+        } else if (info.from === "group") {
+            const group = groups.find(
+                (group) => group.id.toString() === info.id,
+            );
+            count = group ? group.unread : 0;
         }
-        setEntries(
-          entries.map((e) =>
-            e.id === entry.id
-              ? {
-                  ...e,
-                  status: "read",
-                }
-              : { ...e },
-          ),
-        );
-        setAllEntries(
-          allEntries.map((e) =>
-            e.id === entry.id
-              ? {
-                  ...e,
-                  status: "read",
-                }
-              : { ...e },
-          ),
-        );
-      }
-      entryDetailRef.current.scrollTo(0, 0);
-    }
-    clickCard();
-  }
+        setUnreadCount(count);
+        return count;
+    };
 
-  return (
-    <>
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          borderRight: "1px solid var(--color-border-2)",
-        }}
-        className="entry-col"
-      >
-        <CSSTransition
-          in={!loading}
-          timeout={200}
-          nodeRef={cardsRef}
-          classNames="fade"
-        >
-          <div
-            className="entry-list"
-            ref={entryListRef}
-            style={{
-              overflowY: "auto",
-              padding: "10px 10px 0 10px",
-              width: "302px",
-              backgroundColor: "var(--color-fill-1)",
-              flex: "1",
-            }}
-          >
-            <Input.Search
-              allowClear
-              placeholder="filter"
-              value={filterString}
-              addBefore={
-                <Select
-                  placeholder="Please select"
-                  onChange={(value) => {
-                    handelFilterEntry(value, filterStatus, filterString);
-                  }}
-                  style={{ width: 100 }}
-                  value={filterType}
-                >
-                  <Select.Option value="0">Title</Select.Option>
-                  <Select.Option value="1">Content</Select.Option>
-                </Select>
-              }
-              onChange={(value) => {
-                handelFilterEntry(filterType, filterStatus, value);
-                console.log(value);
-              }}
-              style={{
-                marginBottom: "10px",
-                width: "300px",
-              }}
-            />
+    const filterArticles = (articles, status) => status === "all"
+        ? articles
+        : articles.filter((article) => article.status === status);
 
-            {loading &&
-              cards.map((card) => (
-                <Card
-                  style={{ width: 300, marginBottom: "10px" }}
-                  key={card}
-                  cover={
-                    <Skeleton
-                      loading={loading}
-                      animation={true}
-                      text={{ rows: 0 }}
-                      image={{
-                        style: {
-                          width: 300,
-                          height: 160,
-                        },
-                      }}
-                    />
-                  }
-                >
-                  <Card.Meta
-                    description={
-                      <Skeleton
-                        loading={loading}
-                        animation={true}
-                        text={{ rows: 3, width: 150 }}
-                      />
-                    }
-                  />
-                </Card>
-              ))}
-            <div ref={cardsRef}>
-              {entries.map((entry) => (
-                <div style={{ marginBottom: "10px" }} key={entry.id}>
-                  <Card
-                    className={classNames("card-custom-hover-style", {
-                      "card-custom-selected-style": activeContent
-                        ? entry.id === activeContent.id
-                        : false,
-                    })}
-                    hoverable
-                    data-entry-id={entry.id}
-                    style={{ width: 300, cursor: "pointer" }}
-                    onClick={() => {
-                      handelClickEntryList(entry);
-                    }}
-                    cover={
-                      <div
-                        style={{
-                          display: entry.imgSrc ? "block" : "none",
-                          height: 160,
-                          overflow: "hidden",
-                          borderBottom: "1px solid var(--color-border-1)",
-                        }}
-                      >
-                        <ImageWithLazyLoading
-                          width={300}
-                          height={160}
-                          alt={entry.id}
-                          src={entry.imgSrc}
-                          status={entry.status}
-                        />
-                      </div>
-                    }
-                  >
-                    <Card.Meta
-                      description={
-                        <div>
-                          <Typography.Text
-                            style={
-                              entry.status === "unread"
-                                ? { fontWeight: "500" }
-                                : {
-                                    color: "var(--color-text-3)",
-                                    fontWeight: "500",
-                                  }
-                            }
-                          >
-                            {entry.title}
-                          </Typography.Text>
-                          <Typography.Text
-                            style={{
-                              color: "var(--color-text-3)",
-                              fontSize: "13px",
-                            }}
-                          >
-                            <br />
-                            {entry.feed.title.toUpperCase()}
-                          </Typography.Text>
-                        </div>
-                      }
-                    />
-                  </Card>
-                </div>
-              ))}
-            </div>
+    const getFirstImage = entry => {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(entry.content, "text/html");
+        const firstImg = doc.querySelector("img");
+        if (firstImg) {
+            entry.imgSrc = firstImg.getAttribute("src");
+        }
+        return entry;
+    };
 
-            {loadMoreVisible && (
-              <Button
-                onClick={handleLoadMore}
-                loading={loadingMore}
-                long={true}
-                style={{ margin: "10px auto", display: "block" }}
-              >
-                {!loadingMore && <IconArrowDown />}Load more
-              </Button>
-            )}
-          </div>
-        </CSSTransition>
-        <div
-          className="entry-panel"
-          style={{
-            //position: "absolute",
-            backgroundColor: "var(--color-bg-2)",
-            bottom: "0",
-            display: "flex",
-            flexDirection: "row",
-            padding: "8px 10px",
-            //width: "302px",
-            zIndex: "100",
-            justifyContent: "space-between",
-            borderTop: "1px solid var(--color-border-2)",
-          }}
-        >
-          <Radio.Group
-            type="button"
-            name="lang"
-            value={filterStatus}
-            onChange={(value) => {
-              handelFilterEntry(filterType, value, filterString);
-            }}
-          >
-            <Radio value="all">ALL</Radio>
-            <Radio value="unread">UNREAD</Radio>
-          </Radio.Group>
-          <Popconfirm
-            focusLock
-            title="Mark All As Read?"
-            okText="Confirm"
-            cancelText="Cancel"
-            onOk={() => handelMarkAllAsRead()}
-          >
-            <Button icon={<IconCheck />} shape="circle"></Button>
-          </Popconfirm>
-        </div>
-      </div>
-      {activeContent && (
-        <Tooltip
-          position="left"
-          content={
-            activeContent.status === "unread"
-              ? "Mark As Read?"
-              : "Mark As Unread?"
-          }
-        >
-          <Button
-            shape="circle"
-            type="primary"
-            onClick={() => handelUpdateEntry()}
-            icon={
-              activeContent.status === "unread" ? (
-                <IconEye />
-              ) : (
-                <IconEyeInvisible />
-              )
+    const getArticleList = async () => {
+        try {
+            setLoading(true);
+            const response = await getEntries();
+            if (response?.data?.entries) {
+                const fetchedArticles = response.data.entries.map(getFirstImage);
+                setAllEntries(fetchedArticles);
+
+                const filteredArticles = filterArticles(fetchedArticles, filterStatus);
+                setEntries(filteredArticles);
+
+                setTotal(response.data.total);
+                setLoadMoreVisible(fetchedArticles.length < response.data.total);
+
+                const count = updateUnreadCount();
+                setLoadMoreUnreadVisible(filteredArticles.length < count);
             }
-            style={{
-              position: "fixed",
-              bottom: "20px",
-              right: "20px",
-              boxShadow: "0 2px 12px 0 rgba(0,0,0,.1)",
-            }}
-          />
-        </Tooltip>
-      )}
-      <CSSTransition
-        in={animation}
-        timeout={200}
-        nodeRef={entryDetailRef}
-        classNames="fade"
-      >
-        {activeContent ? (
-          <div
-            ref={entryDetailRef}
-            className="article-content"
-            style={{
-              paddingTop: "40px",
-              paddingBottom: "40px",
-              paddingLeft: "5%",
-              paddingRight: "5%",
-              flex: "1",
-              overflowY: "auto",
-              overflowX: "hidden",
-            }}
-          >
+        } catch (error) {
+            console.error("Error fetching articles:", error);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        getArticleList();
+        setActiveContent(null);
+        entryListRef.current.scrollTo(0, 0);
+        entryDetailRef.current.scrollTo(0, 0);
+        setOffset(0);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [info]);
+
+    useEffect(() => {
+        if (initDataCompleted) {
+            const count = updateUnreadCount();
+            setLoadMoreUnreadVisible(entries.length < count);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [initDataCompleted]);
+
+    const handleLoadMore = async () => {
+        try {
+            setLoadingMore(true);
+            const response = await getEntries(offset + 100);
+            if (response?.data?.entries) {
+                setOffset(offset + 100);
+                const newArticlesWithImage = response.data.entries.map(getFirstImage);
+                const updatedAllArticles = [...new Map([...allEntries, ...newArticlesWithImage].map(
+                    entry => [entry.id, entry])).values()
+                ];
+                setAllEntries(updatedAllArticles);
+
+                const filteredArticles = filterArticles(updatedAllArticles, filterStatus);
+                setEntries(filteredArticles);
+                setLoadMoreVisible(updatedAllArticles.length < total);
+                setLoadMoreUnreadVisible(filteredArticles.length < unreadCount);
+            }
+        } catch (error) {
+            console.error("Error fetching more articles:", error);
+        } finally {
+            setLoadingMore(false);
+        }
+    };
+
+    const handelFilterEntry = (filter_type, filter_status, filter_string) => {
+        setFilterType(filter_type);
+        setFilterStatus(filter_status);
+        setFilterString(filter_string);
+        if (filter_type === "0") {
+            setEntries(
+                filter_status === "all"
+                    ? allEntries.filter((entry) => entry.title.includes(filter_string))
+                    : allEntries.filter(
+                        (entry) =>
+                            entry.title.includes(filter_string) &&
+                            entry.status === filter_status,
+                    ),
+            );
+        } else {
+            setEntries(
+                filter_status === "all"
+                    ? allEntries.filter((entry) => entry.content.includes(filter_string))
+                    : allEntries.filter(
+                        (entry) =>
+                            entry.content.includes(filter_string) &&
+                            entry.status === filter_status,
+                    ),
+            );
+        }
+    };
+
+    const handelUpdateEntry = () => {
+        const newStatus = activeContent.status === "read" ? "unread" : "read";
+        const switchArticleStatus = async () => {
+            const response = await updateEntry(activeContent);
+            if (response) {
+                setActiveContent({
+                    ...activeContent,
+                    status: newStatus,
+                });
+                updateFeedUnread(activeContent.feed.id, newStatus);
+                updateGroupUnread(activeContent.feed.category.id, newStatus);
+                setEntries(
+                    entries.map((e) =>
+                        e.id === activeContent.id
+                            ? {
+                                ...e,
+                                status: newStatus,
+                            }
+                            : {...e},
+                    ),
+                );
+                setAllEntries(
+                    allEntries.map((e) =>
+                        e.id === activeContent.id
+                            ? {
+                                ...e,
+                                status: newStatus,
+                            }
+                            : {...e},
+                    ),
+                );
+            }
+        };
+        switchArticleStatus();
+    };
+
+    const handelMarkAllAsRead = () => {
+        const readAll = async () => {
+            const response = await markAllAsRead();
+            response && Message.success("Success");
+            await initData();
+            setAllEntries(allEntries.map((e) => ({...e, status: "read"})));
+            setEntries(entries.map((e) => ({...e, status: "read"})));
+        };
+        readAll();
+    };
+
+    const handelClickEntryList = entry => {
+        const clickCard = async () => {
+            setAnimation(null);
+            const response = await clickEntryList(entry);
+            if (response) {
+                setAnimation(true);
+                setActiveContent({
+                    ...entry,
+                    status: "read",
+                });
+                if (entry.status === "unread") {
+                    updateFeedUnread(entry.feed.id, "read");
+                    updateGroupUnread(entry.feed.category.id, "read");
+                }
+                setEntries(
+                    entries.map((e) =>
+                        e.id === entry.id
+                            ? {
+                                ...e,
+                                status: "read",
+                            }
+                            : {...e},
+                    ),
+                );
+                setAllEntries(
+                    allEntries.map((e) =>
+                        e.id === entry.id
+                            ? {
+                                ...e,
+                                status: "read",
+                            }
+                            : {...e},
+                    ),
+                );
+            }
+            entryDetailRef.current.scrollTo(0, 0);
+        };
+        clickCard();
+    };
+
+    return (
+        <>
             <div
-              className="article-title"
-              style={{
-                maxWidth: "600px",
-                marginLeft: "auto",
-                marginRight: "auto",
-              }}
+                style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    borderRight: "1px solid var(--color-border-2)",
+                }}
+                className="entry-col"
             >
-              <Typography.Text
-                style={{ color: "var(--color-text-3)", fontSize: "10px" }}
-              >
-                {dayjs(activeContent.created_at)
-                  .format("MMMM D, YYYY")
-                  .toUpperCase()}
-                {" AT "}
-                {dayjs(activeContent.created_at).format("hh:mm")}
-              </Typography.Text>
-              <Typography.Title heading={3} style={{ margin: 0 }}>
-                <a
-                  href={activeContent.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <CSSTransition
+                    in={!loading}
+                    timeout={200}
+                    nodeRef={cardsRef}
+                    classNames="fade"
                 >
-                  {activeContent.title}
-                </a>
-              </Typography.Title>
-              <Typography.Text
-                style={{ color: "var(--color-text-3)", fontSize: "10px" }}
-              >
-                {activeContent.feed.title.toUpperCase()}
-              </Typography.Text>
-              <Divider />
+                    <div
+                        className="entry-list"
+                        ref={entryListRef}
+                        style={{
+                            overflowY: "auto",
+                            padding: "10px 10px 0 10px",
+                            width: "302px",
+                            backgroundColor: "var(--color-fill-1)",
+                            flex: "1",
+                        }}
+                    >
+                        <Input.Search
+                            allowClear
+                            placeholder="filter"
+                            value={filterString}
+                            addBefore={
+                                <Select
+                                    placeholder="Please select"
+                                    onChange={(value) => {
+                                        handelFilterEntry(value, filterStatus, filterString);
+                                    }}
+                                    style={{width: 100}}
+                                    value={filterType}
+                                >
+                                    <Select.Option value="0">Title</Select.Option>
+                                    <Select.Option value="1">Content</Select.Option>
+                                </Select>
+                            }
+                            onChange={(value) => {
+                                handelFilterEntry(filterType, filterStatus, value);
+                                console.log(value);
+                            }}
+                            style={{
+                                marginBottom: "10px",
+                                width: "300px",
+                            }}
+                        />
+
+                        {loading &&
+                            cards.map((card) => (
+                                <Card
+                                    style={{width: 300, marginBottom: "10px"}}
+                                    key={card}
+                                    cover={
+                                        <Skeleton
+                                            loading={loading}
+                                            animation={true}
+                                            text={{rows: 0}}
+                                            image={{
+                                                style: {
+                                                    width: 300,
+                                                    height: 160,
+                                                },
+                                            }}
+                                        />
+                                    }
+                                >
+                                    <Card.Meta
+                                        description={
+                                            <Skeleton
+                                                loading={loading}
+                                                animation={true}
+                                                text={{rows: 3, width: 150}}
+                                            />
+                                        }
+                                    />
+                                </Card>
+                            ))}
+                        <div ref={cardsRef}>
+                            {entries.map((entry) => (
+                                <div style={{marginBottom: "10px"}} key={entry.id}>
+                                    <Card
+                                        className={classNames("card-custom-hover-style", {
+                                            "card-custom-selected-style": activeContent
+                                                ? entry.id === activeContent.id
+                                                : false,
+                                        })}
+                                        hoverable
+                                        data-entry-id={entry.id}
+                                        style={{width: 300, cursor: "pointer"}}
+                                        onClick={() => {
+                                            handelClickEntryList(entry);
+                                        }}
+                                        cover={
+                                            <div
+                                                style={{
+                                                    display: entry.imgSrc ? "block" : "none",
+                                                    height: 160,
+                                                    overflow: "hidden",
+                                                    borderBottom: "1px solid var(--color-border-1)",
+                                                }}
+                                            >
+                                                <ImageWithLazyLoading
+                                                    width={300}
+                                                    height={160}
+                                                    alt={entry.id}
+                                                    src={entry.imgSrc}
+                                                    status={entry.status}
+                                                />
+                                            </div>
+                                        }
+                                    >
+                                        <Card.Meta
+                                            description={
+                                                <div>
+                                                    <Typography.Text
+                                                        style={
+                                                            entry.status === "unread"
+                                                                ? {fontWeight: "500"}
+                                                                : {
+                                                                    color: "var(--color-text-3)",
+                                                                    fontWeight: "500",
+                                                                }
+                                                        }
+                                                    >
+                                                        {entry.title}
+                                                    </Typography.Text>
+                                                    <Typography.Text
+                                                        style={{
+                                                            color: "var(--color-text-3)",
+                                                            fontSize: "13px",
+                                                        }}
+                                                    >
+                                                        <br/>
+                                                        {entry.feed.title.toUpperCase()}
+                                                    </Typography.Text>
+                                                </div>
+                                            }
+                                        />
+                                    </Card>
+                                </div>
+                            ))}
+                        </div>
+                        {filterStatus === "all" && loadMoreVisible && (
+                            <Button
+                                onClick={handleLoadMore}
+                                loading={loadingMore}
+                                long={true}
+                                style={{margin: "10px auto", display: "block"}}
+                            >
+                                {!loadingMore && <IconArrowDown/>}Load more
+                            </Button>
+                        )}
+
+                        {filterStatus === "unread" && loadMoreUnreadVisible && (
+                            <Button
+                                onClick={handleLoadMore}
+                                loading={loadingMore}
+                                long={true}
+                                style={{margin: "10px auto", display: "block"}}
+                            >
+                                {!loadingMore && <IconArrowDown/>}Load more
+                            </Button>
+                        )}
+                    </div>
+                </CSSTransition>
+                <div
+                    className="entry-panel"
+                    style={{
+                        // position: "absolute",
+                        backgroundColor: "var(--color-bg-2)",
+                        bottom: "0",
+                        display: "flex",
+                        flexDirection: "row",
+                        padding: "8px 10px",
+                        // width: "302px",
+                        zIndex: "100",
+                        justifyContent: "space-between",
+                        borderTop: "1px solid var(--color-border-2)",
+                    }}
+                >
+                    <Radio.Group
+                        type="button"
+                        name="lang"
+                        value={filterStatus}
+                        onChange={(value) => {
+                            handelFilterEntry(filterType, value, filterString);
+                        }}
+                    >
+                        <Radio value="all">ALL</Radio>
+                        <Radio value="unread">UNREAD</Radio>
+                    </Radio.Group>
+                    <Popconfirm
+                        focusLock
+                        title="Mark All As Read?"
+                        okText="Confirm"
+                        cancelText="Cancel"
+                        onOk={() => handelMarkAllAsRead()}
+                    >
+                        <Button icon={<IconCheck/>} shape="circle"></Button>
+                    </Popconfirm>
+                </div>
             </div>
-            <div
-              dangerouslySetInnerHTML={{ __html: activeContent.content }}
-              className="article-body"
-              style={{
-                fontSize: "1.2em",
-                overflowWrap: "break-word",
-                maxWidth: "600px",
-                marginLeft: "auto",
-                marginRight: "auto",
-              }}
-            ></div>
-          </div>
-        ) : (
-          <div
-            ref={entryDetailRef}
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              backgroundColor: "var(--color-fill-1)",
-              color: "var(--color-text-3)",
-              alignItems: "center",
-              justifyContent: "center",
-              flex: "1",
-              padding: "40px 16px",
-            }}
-          >
-            <IconEmpty style={{ fontSize: "64px" }} />
-            <Typography.Title
-              heading={6}
-              style={{ color: "var(--color-text-3)", marginTop: "10px" }}
+            {activeContent && (
+                <Tooltip
+                    position="left"
+                    content={
+                        activeContent.status === "unread"
+                            ? "Mark As Read?"
+                            : "Mark As Unread?"
+                    }
+                >
+                    <Button
+                        shape="circle"
+                        type="primary"
+                        onClick={() => handelUpdateEntry()}
+                        icon={
+                            activeContent.status === "unread" ? (
+                                <IconEye/>
+                            ) : (
+                                <IconEyeInvisible/>
+                            )
+                        }
+                        style={{
+                            position: "fixed",
+                            bottom: "20px",
+                            right: "20px",
+                            boxShadow: "0 2px 12px 0 rgba(0,0,0,.1)",
+                        }}
+                    />
+                </Tooltip>
+            )}
+            <CSSTransition
+                in={animation}
+                timeout={200}
+                nodeRef={entryDetailRef}
+                classNames="fade"
             >
-              {"Reactflux".toUpperCase()}
-            </Typography.Title>
-          </div>
-        )}
-      </CSSTransition>
-    </>
-  );
+                {activeContent ? (
+                    <div
+                        ref={entryDetailRef}
+                        className="article-content"
+                        style={{
+                            paddingTop: "40px",
+                            paddingBottom: "40px",
+                            paddingLeft: "5%",
+                            paddingRight: "5%",
+                            flex: "1",
+                            overflowY: "auto",
+                            overflowX: "hidden",
+                        }}
+                    >
+                        <div
+                            className="article-title"
+                            style={{
+                                maxWidth: "600px",
+                                marginLeft: "auto",
+                                marginRight: "auto",
+                            }}
+                        >
+                            <Typography.Text
+                                style={{color: "var(--color-text-3)", fontSize: "10px"}}
+                            >
+                                {dayjs(activeContent.created_at)
+                                    .format("MMMM D, YYYY")
+                                    .toUpperCase()}
+                                {" AT "}
+                                {dayjs(activeContent.created_at).format("hh:mm")}
+                            </Typography.Text>
+                            <Typography.Title heading={3} style={{margin: 0}}>
+                                <a
+                                    href={activeContent.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    {activeContent.title}
+                                </a>
+                            </Typography.Title>
+                            <Typography.Text
+                                style={{color: "var(--color-text-3)", fontSize: "10px"}}
+                            >
+                                {activeContent.feed.title.toUpperCase()}
+                            </Typography.Text>
+                            <Divider/>
+                        </div>
+                        <div
+                            dangerouslySetInnerHTML={{__html: activeContent.content}}
+                            className="article-body"
+                            style={{
+                                fontSize: "1.2em",
+                                overflowWrap: "break-word",
+                                maxWidth: "600px",
+                                marginLeft: "auto",
+                                marginRight: "auto",
+                            }}
+                        ></div>
+                    </div>
+                ) : (
+                    <div
+                        ref={entryDetailRef}
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            backgroundColor: "var(--color-fill-1)",
+                            color: "var(--color-text-3)",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            flex: "1",
+                            padding: "40px 16px",
+                        }}
+                    >
+                        <IconEmpty style={{fontSize: "64px"}}/>
+                        <Typography.Title
+                            heading={6}
+                            style={{color: "var(--color-text-3)", marginTop: "10px"}}
+                        >
+                            {"Reactflux".toUpperCase()}
+                        </Typography.Title>
+                    </div>
+                )}
+            </CSSTransition>
+        </>
+    );
 }

--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import {CSSTransition} from "react-transition-group";
 import {useStore} from "../App";
 import {useEffect, useRef, useState} from "react";
+import {Link} from "react-router-dom";
 import {
     Button,
     Card,
@@ -564,7 +565,12 @@ export default function Content({info, getEntries, markAllAsRead}) {
                             <Typography.Text
                                 style={{color: "var(--color-text-3)", fontSize: "10px"}}
                             >
-                                {activeContent.feed.title.toUpperCase()}
+                                <Link
+                                    to={`/feed/${activeContent.feed.id}`}
+                                    style={{color: 'inherit', textDecoration: 'none'}}
+                                >
+                                    {activeContent.feed.title.toUpperCase()}
+                                </Link>
                             </Typography.Text>
                             <Divider/>
                         </div>


### PR DESCRIPTION
- refactor: 重构并修正 `加载更多` 按钮的相关逻辑，优化数据处理与状态更新逻辑
- feat: 在文章详情页面中，将订阅源文本转换为可点击链接；点击该链接后，侧边栏的焦点将同步更新

UPDATE:
- feat: 点击文章列表中的卡片后，焦点切换到文章详情页，按下 ESC 键返回；左右方向键切换到上下一篇文章；M 键标记已读 / 未读； S 键收藏 / 取消，并添加按钮和相应的接口