### PR TITLE
Support Bluesky videos from OpenRSS feeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ofetch": "^1.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hls-video-player": "^3.2.4",
     "react-hotkeys-hook": "^4.6.1",
     "react-intersection-observer": "^9.13.1",
     "react-photo-view": "^1.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-hls-video-player:
+        specifier: ^3.2.4
+        version: 3.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-hotkeys-hook:
         specifier: ^4.6.1
         version: 4.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1840,6 +1843,9 @@ packages:
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
+  hls.js@1.5.17:
+    resolution: {integrity: sha512-wA66nnYFvQa1o4DO/BFgLNRKnBTVXpNeldGRBJ2Y0SvFtdwvFKCbqa9zhHoZLoxHhZ+jYsj3aIBkWQQCPNOhMw==}
+
   homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
@@ -2418,6 +2424,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-hls-video-player@3.2.4:
+    resolution: {integrity: sha512-P2GSZt+Lmzk5nswtCYXG+thL0jlBR0Giuy9iII84o2L64a6zylQE4WUD8U/IG9kfLxfQ7f1DUfNbkov5aVp5cw==}
+    peerDependencies:
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   react-hotkeys-hook@4.6.1:
     resolution: {integrity: sha512-XlZpbKUj9tkfgPgT9gA+1p7Ey6vFIZHttUjPqpTdyT5nqQ8mHL7elxvSbaC+dpSiHUSmr21Ya1mDxBZG3aje4Q==}
@@ -5000,6 +5012,8 @@ snapshots:
 
   highlightjs-vue@1.0.0: {}
 
+  hls.js@1.5.17: {}
+
   homedir-polyfill@1.0.3:
     dependencies:
       parse-passwd: 1.0.0
@@ -5533,6 +5547,12 @@ snapshots:
       use-sidecar: 1.1.2(@types/react@18.3.12)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.12
+
+  react-hls-video-player@3.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      hls.js: 1.5.17
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-hotkeys-hook@4.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/src/components/Article/ArticleDetail.jsx
+++ b/src/components/Article/ArticleDetail.jsx
@@ -2,6 +2,7 @@ import { Divider, Tag, Typography } from "@arco-design/web-react";
 import ReactHtmlParser from "html-react-parser";
 import { littlefoot } from "littlefoot";
 import { forwardRef, useEffect } from "react";
+import ReactHlsPlayer from "react-hls-video-player";
 import { PhotoSlider } from "react-photo-view";
 import { useNavigate } from "react-router-dom";
 import sanitizeHtml from "../../utils/sanitizeHtml";
@@ -44,6 +45,24 @@ const getHtmlParserOptions = (imageSources, togglePhotoSlider) => ({
         );
       }
     } else if (node.type === "tag" && node.name === "img") {
+      if (/video\.bsky\.app.*thumbnail\.jpg$/.test(node.attribs.src)) {
+        // bsky video from openrss
+        const thumbnail = node.attribs.src;
+        const videoSrc = thumbnail.replace("thumbnail.jpg", "playlist.m3u8");
+        return (
+          <ReactHlsPlayer
+            src={videoSrc}
+            controls={true}
+            loop={true}
+            poster={thumbnail}
+            playsInline={true}
+            hlsConfig={{
+              startLevel: -1, // force autolevel
+            }}
+          />
+        );
+      }
+
       const index = imageSources.findIndex((src) => src === node.attribs.src);
       return (
         <ImageOverlayButton

--- a/src/hooks/useScreenWidth.js
+++ b/src/hooks/useScreenWidth.js
@@ -1,16 +1,24 @@
 import { useEffect, useState } from "react";
 
 export const useScreenWidth = () => {
-  const [width, setWidth] = useState(window.innerWidth);
-  const isBelowMedium = width <= 768;
-  const isBelowLarge = width <= 992;
+  const mediumThreshold = 768;
+  const largeThreshold = 992;
+  const [isBelowMedium, setIsBelowMedium] = useState(
+    window.innerWidth <= mediumThreshold,
+  );
+  const [isBelowLarge, setIsBelowLarge] = useState(
+    window.innerWidth <= largeThreshold,
+  );
 
   useEffect(() => {
-    const handleResize = () => setWidth(window.innerWidth);
+    const handleResize = () => {
+      setIsBelowMedium(window.innerWidth <= mediumThreshold);
+      setIsBelowLarge(window.innerWidth <= largeThreshold);
+    };
 
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
   }, []);
 
-  return { width, isBelowMedium, isBelowLarge };
+  return { isBelowMedium, isBelowLarge };
 };


### PR DESCRIPTION
Bluesky's videos are of the form `https://video.bsky.app/watch/.../playlist.m3u8` with the thumbnail `https://video.bsky.app/watch/.../thumbnail.jpg`.
OpenRSS embeds the thumbnail image for videos, so we can derive the video url and play it as HLS.

Also, prevent rerendering components on window resize if we don't cross a threshold. (This ensures that the video isn't recreated everytime we resize the window.)