### PR TITLE
Enable iOS PWA standalone mode to hide address bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta content="black-translucent" name="apple-mobile-web-app-status-bar-style" />
     <meta
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"


### PR DESCRIPTION
Added `apple-mobile-web-app-capable` meta tag to enable full-screen mode on iOS PWAs. This hides the Safari address bar when the app is added to the home screen (similar to how it shows for example in Chrome when "installed").